### PR TITLE
Adopt clue-based puzzle format and smarter boot logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,169 +102,105 @@
   <!-- Inline puzzle fallback -->
   <script id="puzzleData" type="application/json">
     {
-      "id": "2025-08-19",
+      "id": "000001",
       "grid": {
         "rows": 5,
         "cols": 5,
-        "blocks": [[1, 1], [1, 3], [3, 1], [3, 3]],
+        "blocks": [[1,1], [1,3], [3,1], [3,3]],
         "numbers": {
-          "all": [[0, 0, "1"], [0, 2, "2"], [0, 4, "3"], [2, 0, "2"], [4, 0, "3"]]
+          "all": [[0,0,"1"], [0,2,"2"], [0,4,"3"], [2,0,"2"], [4,0,"3"]]
         }
       },
-      "entries": [
+      "clues": [
         {
-          "id": "1A",
-          "direction": "across",
-          "row": 0,
-          "col": 0,
-          "answer": "DISCO",
-          "clue": {
-            "surface": "At first, did I seem cautious over a certain type of fever? (5)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "acrostic",
-                "text": "At first",
-                "tooltip": "Acrostic Indicator - take the first letters of the following words:"
-              },
-              {
-                "type": "fodder",
-                "text": "did I seem cautious over",
-                "tooltip": ";) D id I S eem C autious O ver ;)"
-              },
-              {
-                "type": "definition",
-                "text": "a certain type of fever?",
-                "tooltip": "The Definition"
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "A",
+          "number": 1,
+          "difficulty": 1,
+          "solution": "DEBUT",
+          "clue": "Returns \"tubed\" for his first appearance.",
+          "clueType": "reversal",
+          "definition": "his first appearance",
+          "tooltips": [
+            {"type": "definition", "section": "his first appearance", "text": "This is the Definition"},
+            {"type": "reversal", "section": "Returns", "text": "Wordplay: 'returns' tells you to reverse the letters in tubed"},
+            {"type": "fodder", "section": "tubed", "text": "Wordplay: These letters are what we call the 'fodder', these are the letters (or words) that you use to make up your answer."}
+          ]
         },
         {
-          "id": "2A",
-          "direction": "across",
-          "row": 2,
-          "col": 0,
-          "answer": "INANE",
-          "clue": {
-            "surface": "Win a necktie within (Boring!) (5)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "hidden",
-                "text": "Within",
-                "tooltip": "Look WITHIN, \"win a neck...\""
-              },
-              {
-                "type": "fodder",
-                "text": "Win a necktie",
-                "tooltip": "wINANEcktie"
-              },
-              {
-                "type": "definition",
-                "text": "(Boring!)",
-                "tooltip": "The Definition"
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "A",
+          "number": 2,
+          "difficulty": 2,
+          "solution": "TASTE",
+          "clue": "State is upset with your style.",
+          "clueType": "anagram",
+          "definition": "your style",
+          "tooltips": [
+            {"type": "definition", "section": "your style", "text": "This is the Definition"}
+          ]
         },
         {
-          "id": "3A",
-          "direction": "across",
-          "row": 4,
-          "col": 0,
-          "answer": "TAROT",
-          "clue": {
-            "surface": "Endlessly rotate and shuffle these cards (5)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "deletion",
-                "text": "Endlessly",
-                "tooltip": "the next word, with no end? (ROTAT-e)"
-              },
-              {
-                "type": "fodder",
-                "text": "rotate and",
-                "tooltip": "Make it endless then follow the next instruction..."
-              },
-              {
-                "type": "indicator",
-                "category": "anagram",
-                "text": "shuffle",
-                "tooltip": "Shuffle the remaining letters (ROTAT) to get these cards..."
-              },
-              {
-                "type": "definition",
-                "text": "these cards",
-                "tooltip": "The Definition"
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "A",
+          "number": 3,
+          "difficulty": 3,
+          "solution": "SEDGE",
+          "clue": "Carex seen on rivers edge!",
+          "clueType": "literally",
+          "definition": "Carex seen on rivers edge",
+          "tooltips": [
+            {"type": "definition", "section": "Carex seen on rivers edge", "text": "This is the Definition"},
+            {"type": "container", "section": "seen on", "text": "Wordplay: 'Seen on' indicates that you will find the answer contained inside the words 'rivers edge'"},
+            {"type": "fodder", "section": "rivers edge", "text": "Wordplay: These letters are what we call the 'fodder', these are the letters (or words) that you use to make up your answer."},
+            {"type": "literally", "section": "!", "text": "...and literally so! aka &lit, a rare clue where what you see is what you get. The exclamation mark tells you that the answer is also literally a \"Carex seen on rivers edge!\""}
+          ]
         },
         {
-          "id": "1D",
-          "direction": "down",
-          "row": 0,
-          "col": 0,
-          "answer": "DRIFT",
-          "clue": {
-            "surface": "Five hundred fight and then go with the tide. (5)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "charade",
-                "text": "Five hundred",
-                "tooltip": "Five Hundred Romans, Perhaps? (Just one letter)"
-              },
-              {
-                "type": "fodder",
-                "text": "fight and then",
-                "tooltip": "Another word for a fight? (rhymes with \"lift\")"
-              },
-              {
-                "type": "definition",
-                "text": "go with the tide",
-                "tooltip": "The Definition"
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "D",
+          "number": 1,
+          "difficulty": 1,
+          "solution": "DATES",
+          "clue": "Lost within, Brad ate some wrinkly fruit.",
+          "clueType": "container",
+          "definition": "wrinkly fruit",
+          "tooltips": [
+            {"type": "definition", "section": "wrinkly fruit", "text": "This is the Definition"},
+            {"type": "container", "section": "Lost within", "text": "Wordplay: 'Lost within' indicates that you will find the answer contained inside the words 'Brad ate some'"},
+            {"type": "fodder", "section": "Brad ate some", "text": "Wordplay: These letters are what we call the 'fodder', these are the letters (or words) that you use to make up your answer."}
+          ],
+          "comment": "I know the \"Lost\" isn't technically Ximenean, but I just liked the surface, hinting that Brad was so hungry and lost (Within what, a cave? A Forest?!), that he'd eaten some strange wrinkly fruit…"
         },
         {
-          "id": "2D",
-          "direction": "down",
-          "row": 0,
-          "col": 2,
-          "answer": "STAIR",
-          "clue": {
-            "surface": "A single step!, (&Lit) (5)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "lit",
-                "text": "A single step!",
-                "tooltip": "...and literally so! aka &lit, a rare clue where what you see is what you get, sorry, not sorry, but that's all you get!"
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "D",
+          "number": 2,
+          "difficulty": 2,
+          "solution": "BASED",
+          "clue": "Bashed the hydrogen out to see where it's founded.",
+          "clueType": "charade",
+          "definition": "where it's founded",
+          "tooltips": [
+            {"type": "definition", "section": "where it's founded", "text": "This is the Definition"},
+            {"type": "charade", "section": "to see where", "text": "Wordplay: 'to see where' indicates that you will take actions to build the answer. What happens when you take hydrogen out of Bashed?"},
+            {"type": "fodder", "section": "Bashed the hydrogen out", "text": "Wordplay: These letters are what we call the 'fodder', these are the letters (or words) that you use to make up your answer."}
+          ]
         },
         {
-          "id": "3D",
-          "direction": "down",
-          "row": 0,
-          "col": 4,
-          "answer": "OVERT",
-          "clue": {
-            "surface": "Over the top! (5) (&lit)",
-            "segments": [
-              {
-                "type": "indicator",
-                "category": "lit",
-                "text": "Over the top!",
-                "tooltip": "...and literally so! aka &lit, an.. oops, not so rare clue where - oh you get the picture, no? Over+the top of \"the\" being \"t\" Over+t = OVERT, which overtly, is over the top... and literally so."
-              }
-            ]
-          }
+          "crossword": "000001",
+          "direction": "D",
+          "number": 3,
+          "difficulty": 3,
+          "solution": "THEME",
+          "clue": "Herb's Youth-Leader leaves for the East. That's the main idea.",
+          "clueType": "charade",
+          "definition": "That's the main idea.",
+          "tooltips": [
+            {"type": "definition", "section": "That's the main idea.", "text": "This is the Definition"},
+            {"type": "charade", "section": "Herb's Youth-Leader leaves", "text": "Wordplay: Think of a Herb that fits in the space, 'Youth-Leader leaves' tells you to remove the letter Y from your herb (If you don't have a letter 'Y', I'm sorry to inform you that you chose the wrong herb.)"},
+            {"type": "charade", "section": "for the East.", "text": "Wordplay: 'for the' here plays a tricky little indicator to tell you to swap the letter out for: (E)ast - East is often an indicator for the letter 'E', from the E on a compass."}
+          ]
         }
       ]
     }

--- a/script.js
+++ b/script.js
@@ -496,26 +496,30 @@ window.addEventListener('load', () => {
   let inlineLoaded = false;
   const inline = document.getElementById('puzzleData');
   if (inline && inline.textContent) {
-    try {
-      const parsed = JSON.parse(inline.textContent);
-      const converted = convertClues(parsed, CROSSWORD_ID);
-      if (converted.length) {
-        puzzle = parsed;
-        puzzle.entries = converted;
-        inlineLoaded = true;
+      try {
+        const parsed = JSON.parse(inline.textContent);
+        if (Array.isArray(parsed.entries) && parsed.entries.length) {
+          puzzle = parsed;
+          inlineLoaded = true;
+        } else {
+          const converted = convertClues(parsed, CROSSWORD_ID);
+          if (converted.length) {
+            puzzle = parsed;
+            puzzle.entries = converted;
+            inlineLoaded = true;
+          }
+        }
+      } catch (e) {
+        console.error('Inline JSON parse failed', e);
       }
-    } catch (e) {
-      console.error('Inline JSON parse failed', e);
     }
-  }
-  if (inlineLoaded) {
-    puzzle.entries = convertClues(puzzle, CROSSWORD_ID);
-    buildGrid();
-    placeEntries();
-    setCurrentEntry((puzzle.entries || [])[0]);
-    return;
-  }
-  // 2) Fallback to fetching the file relative to this location
+    if (inlineLoaded) {
+      buildGrid();
+      placeEntries();
+      setCurrentEntry((puzzle.entries || [])[0]);
+      return;
+    }
+// 2) Fallback to fetching the file relative to this location
   fetch(FILE)
     .then(r => {
       if (!r.ok) throw new Error(`Failed to load ${FILE}: ${r.status}`);


### PR DESCRIPTION
## Summary
- Inline puzzle data now uses the new clue-based format for crossword `000001`
- Boot logic checks for pre-converted `entries` before calling `convertClues`

## Testing
- `node --check script.js`
- `curl -I http://localhost:8000/Clues.json` (via local `python -m http.server`)


------
https://chatgpt.com/codex/tasks/task_e_68adbf974504832bb6d4e7c13fe81a43